### PR TITLE
refactor: add maxFontSizeMultiplier props for limit max font scale

### DIFF
--- a/dist/index.tsx
+++ b/dist/index.tsx
@@ -11,6 +11,8 @@ const HALF_RAD = Math.PI/2
 export default class AnimateNumber extends Component {
 
   props: {
+    // Text Component의 최대 폰트 크기 배율 설정
+    maxFontSizeMultiplier?: number | null | undefined,
     countBy?: number,
     interval?: number,
     steps?: number,


### PR DESCRIPTION
Add the `maxFontSizeMultiplier` prop to set the maximum font size scaling factor.
